### PR TITLE
routing for unknown path without exception

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,7 +9,33 @@ class ApplicationController < ActionController::Base
   before_action :set_cities_link_cloud
   before_action :set_header_class
 
+  rescue_from ActiveRecord::RecordNotFound, with: :not_found
+  rescue_from Exception, with: :not_found
+  rescue_from ActionController::RoutingError, with: :not_found
+
+
+
+  def raise_not_found
+    raise ActionController::RoutingError.new("No route matches #{params[:unmatched_route]}")
+  end
+
   protected
+  def not_found
+    respond_to do |format|
+      format.html { render file: "#{Rails.root}/errors/404", layout: false, status: :not_found }
+      format.xml { head :not_found }
+      format.any { head :not_found }
+    end
+  end
+
+  def error
+    respond_to do |format|
+      format.html { render file: "#{Rails.root}/errors/500", layout: false, status: :error }
+      format.xml { head :not_found }
+      format.any { head :not_found }
+    end
+  end
+
 
   # Needed to easyly access google maps
   def create_simple_locations(locations)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,4 +103,8 @@ Rails.application.routes.draw do
   # Fast exit hack attempts
   get 'wp-login.php', to: 'errors#show', code: 404
   get 'blog/wp-login.php', to: 'errors#show', code: 404
+
+  # Wildcard for unmatched routes
+  get '*unmatched_route', to: 'application#raise_not_found'
+
 end


### PR DESCRIPTION
A not found should not generate one dozend of log entries just to show the inner routing exception 